### PR TITLE
perf:为comment设立缓存，实现批量缓存查询和数据库查询 fix:修复GetLikeStatus，使用查看评论的用户作为userID而非评论作者

### DIFF
--- a/application/service/comment.go
+++ b/application/service/comment.go
@@ -58,7 +58,7 @@ func (s *CommentService) CreateComment(ctx context.Context, req *cmd.CreateComme
 		log.CtxError(ctx, "Failed to insert comment for userID=%s: %v", userID, err)
 		return nil, err
 	}
-	vo, err := s.CommentDto.ToCommentVO(ctx, newComment)
+	vo, err := s.CommentDto.ToCommentVO(ctx, newComment, userID)
 	if err != nil {
 		log.CtxError(ctx, "ToCommentVO failed for userID=%s: %v", userID, err)
 		return nil, errorx.ErrCommentDB2VO
@@ -106,7 +106,7 @@ func (s *CommentService) GetMyComments(ctx context.Context, req *cmd.GetMyCommen
 		return nil, errorx.ErrFindSuccessButNoResult
 	}
 	// 数据转化db2vo
-	myCommentVOs, err := s.CommentDto.ToMyCommentVOList(ctx, comments)
+	myCommentVOs, err := s.CommentDto.ToMyCommentVOList(ctx, comments, userID)
 	if err != nil {
 		log.CtxError(ctx, "ToMyCommentVOList failed for userID=%s: %v", userID, err)
 		return nil, errorx.ErrCommentDB2VO

--- a/infra/cache/like.go
+++ b/infra/cache/like.go
@@ -1,0 +1,95 @@
+package cache
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/Boyuan-IT-Club/Meowpick-Backend/infra/config"
+	"github.com/zeromicro/go-zero/core/stores/redis"
+)
+
+type ILikeCache interface {
+	// 点赞数相关
+	GetLikeCount(ctx context.Context, targetID string) (int64, bool)
+	SetLikeCount(ctx context.Context, targetID string, count int64, expiration time.Duration) error
+	IncrLikeCount(ctx context.Context, targetID string, delta int64) (int64, error)
+	DelLikeCount(ctx context.Context, targetID string) error
+
+	// 点赞状态相关
+	GetLikeStatus(ctx context.Context, userID, targetID string) (bool, bool)
+	SetLikeStatus(ctx context.Context, userID, targetID string, liked bool, expiration time.Duration) error
+	DelLikeStatus(ctx context.Context, userID, targetID string) error
+}
+
+type LikeCache struct {
+	client *redis.Redis
+}
+
+func NewLikeCache(config *config.Config) *LikeCache {
+	rds := redis.MustNewRedis(*config.Redis)
+	return &LikeCache{
+		client: rds,
+	}
+}
+
+// GetLikeCount 点赞数缓存操作
+func (r *LikeCache) GetLikeCount(ctx context.Context, targetID string) (int64, bool) {
+	key := "like:count:" + targetID
+	val, err := r.client.Get(key)
+	if err != nil {
+		return 0, false
+	}
+	count, err := strconv.ParseInt(val, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return count, true
+}
+
+func (r *LikeCache) SetLikeCount(ctx context.Context, targetID string, count int64, expiration time.Duration) error {
+	key := "like:count:" + targetID
+	return r.client.Setex(key, strconv.FormatInt(count, 10), int(expiration.Seconds()))
+}
+
+func (r *LikeCache) IncrLikeCount(ctx context.Context, targetID string, delta int64) (int64, error) {
+	key := "like:count:" + targetID
+	if delta == 1 {
+		return r.client.Incr(key)
+	} else if delta == -1 {
+		return r.client.Decr(key)
+	} else {
+		return r.client.Incrby(key, delta)
+	}
+}
+
+func (r *LikeCache) DelLikeCount(ctx context.Context, targetID string) error {
+	key := "like:count:" + targetID
+	_, err := r.client.Del(key)
+	return err
+}
+
+// 点赞状态缓存操作
+func (r *LikeCache) GetLikeStatus(ctx context.Context, userID, targetID string) (bool, bool) {
+	key := "like:status:" + userID + ":" + targetID
+	val, err := r.client.Get(key)
+	if err != nil {
+		return false, false
+	}
+	liked, err := strconv.ParseBool(val)
+	if err != nil {
+		return false, false
+	}
+	return liked, true
+}
+
+func (r *LikeCache) SetLikeStatus(ctx context.Context, userID, targetID string, liked bool, expiration time.Duration) error {
+	key := "like:status:" + userID + ":" + targetID
+	return r.client.Setex(key, strconv.FormatBool(liked), int(expiration.Seconds()))
+}
+
+func (r *LikeCache) DelLikeStatus(ctx context.Context, userID, targetID string) error {
+	key := "like:status:" + userID + ":" + targetID
+	_, err := r.client.Del(key)
+	return err
+}

--- a/infra/cache/likecache.go
+++ b/infra/cache/likecache.go
@@ -12,12 +12,14 @@ import (
 type ILikeCache interface {
 	// 点赞数相关
 	GetLikeCount(ctx context.Context, targetID string) (int64, bool)
+	GetBatchLikeCount(ctx context.Context, targetIDs []string, targetType int32) (map[string]int64, []string, error)
 	SetLikeCount(ctx context.Context, targetID string, count int64, expiration time.Duration) error
 	IncrLikeCount(ctx context.Context, targetID string, delta int64) (int64, error)
 	DelLikeCount(ctx context.Context, targetID string) error
 
 	// 点赞状态相关
 	GetLikeStatus(ctx context.Context, userID, targetID string) (bool, bool)
+	GetBatchLikeStatus(ctx context.Context, userID string, targetID []string, targetType int32) (map[string]bool, []string, error)
 	SetLikeStatus(ctx context.Context, userID, targetID string, liked bool, expiration time.Duration) error
 	DelLikeStatus(ctx context.Context, userID, targetID string) error
 }
@@ -69,6 +71,49 @@ func (r *LikeCache) DelLikeCount(ctx context.Context, targetID string) error {
 	return err
 }
 
+// GetBatchLikeCount 批量获取缓存，返回命中的id->LikeCount映射和未命中id列表
+// 未命中id列表应作为mapper层聚合查询参数和SetBatchLikeCount的缓存键
+func (r *LikeCache) GetBatchLikeCount(ctx context.Context, targetIDs []string, targetType int32) (map[string]int64, []string, error) {
+	if len(targetIDs) == 0 {
+		return make(map[string]int64), nil, nil
+	}
+
+	// 构建所有的缓存键
+	keys := make([]string, len(targetIDs))
+	for i, targetID := range targetIDs {
+		keys[i] = "like:count:" + targetID
+	}
+
+	// 使用 MGET 批量获取
+	values, err := r.client.Mget(keys...)
+	if err != nil {
+		return nil, targetIDs, err // 缓存失败，返回所有ID作为未命中
+	}
+
+	result := make(map[string]int64) // 命中的结果
+	var missingIDs []string          // 未命中id列表
+	// 遍历批量获取到的缓存结果
+	for i, val := range values {
+		targetID := targetIDs[i]
+		if val == "" {
+			// 缓存未命中，将id加入missingIDs
+			missingIDs = append(missingIDs, targetID)
+		} else {
+			// 缓存命中，解析数值
+			count, parseErr := strconv.ParseInt(val, 10, 64)
+			if parseErr != nil {
+				// 解析失败，视为未命中
+				missingIDs = append(missingIDs, targetID)
+			} else {
+				// 缓存命中且解析成功，加入result
+				result[targetID] = count
+			}
+		}
+	}
+
+	return result, missingIDs, nil
+}
+
 // 点赞状态缓存操作
 func (r *LikeCache) GetLikeStatus(ctx context.Context, userID, targetID string) (bool, bool) {
 	key := "like:status:" + userID + ":" + targetID
@@ -92,4 +137,44 @@ func (r *LikeCache) DelLikeStatus(ctx context.Context, userID, targetID string) 
 	key := "like:status:" + userID + ":" + targetID
 	_, err := r.client.Del(key)
 	return err
+}
+
+func (r *LikeCache) GetBatchLikeStatus(ctx context.Context, userID string, targetIDs []string, targetType int32) (map[string]bool, []string, error) {
+	if len(targetIDs) == 0 {
+		return make(map[string]bool), nil, nil
+	}
+
+	// 构建所有的缓存键
+	keys := make([]string, len(targetIDs))
+	for i, targetID := range targetIDs {
+		keys[i] = "like:status:" + userID + ":" + targetID
+	}
+
+	// 使用 MGET 批量获取
+	values, err := r.client.Mget(keys...)
+	if err != nil {
+		return nil, targetIDs, err // MGET失败，返回所有ID作为未命中
+	}
+
+	result := make(map[string]bool)
+	var missingIDs []string
+
+	for i, val := range values {
+		targetID := targetIDs[i]
+		if val == "" {
+			// 缓存未命中
+			missingIDs = append(missingIDs, targetID)
+		} else {
+			// 缓存命中，解析布尔值
+			liked, parseErr := strconv.ParseBool(val)
+			if parseErr != nil {
+				// 解析失败，视为未命中
+				missingIDs = append(missingIDs, targetID)
+			} else {
+				result[targetID] = liked
+			}
+		}
+	}
+
+	return result, missingIDs, nil
 }

--- a/infra/mapper/like/mongo.go
+++ b/infra/mapper/like/mongo.go
@@ -26,6 +26,10 @@ type IMongoMapper interface {
 	GetLikeStatus(ctx context.Context, userID, targetID string, targetType int32) (bool, error)
 	// GetLikeCount 获得目标的总点赞数
 	GetLikeCount(ctx context.Context, targetID string, targetType int32) (int64, error)
+	// GetBatchLikeStatus 批量获取一个用户对多个目标的点赞状态，返回目标id->bool映射
+	GetBatchLikeStatus(ctx context.Context, userID string, targetID []string, targetType int32) (map[string]bool, error)
+	// GetBatchLikeCount 批量获取多个目标的点赞数
+	GetBatchLikeCount(ctx context.Context, userID string, targetID []string, targetType int32) (map[string]int64, error)
 }
 
 type MongoMapper struct {
@@ -138,4 +142,143 @@ func (m *MongoMapper) GetLikeCount(ctx context.Context, targetID string, targetT
 		return 0, errorx.ErrCountFailed
 	}
 	return count, nil
+}
+
+func (m *MongoMapper) GetBatchLikeStatus(ctx context.Context, userID string, targetIDs []string, targetType int32) (map[string]bool, error) {
+	if len(targetIDs) == 0 {
+		return make(map[string]bool), nil
+	}
+
+	// 先查缓存
+	cachedResults, missingIDs, err := m.likeCache.GetBatchLikeStatus(ctx, userID, targetIDs, targetType)
+	if err != nil {
+		log.Error("Batch get like status from cache error", err)
+		// 缓存失败，直接查数据库
+	}
+	// 提前创建待返回的结果
+	result := cachedResults
+
+	// 如果有未命中的ID，查询数据库
+	if len(missingIDs) > 0 {
+		// 使用聚合查询批量获取点赞状态
+		pipeline := []bson.M{
+			{
+				"$match": bson.M{
+					consts.UserId:   userID,
+					consts.TargetId: bson.M{"$in": missingIDs},
+					consts.Active:   bson.M{"$ne": false},
+				},
+			},
+			{
+				"$group": bson.M{
+					"_id": "$" + consts.TargetId,
+				},
+			},
+		}
+
+		// 临时结果结构体
+		type aggResult struct {
+			ID string `bson:"_id"`
+		}
+		var results []aggResult
+
+		// 执行聚合查询，结果填充到 results
+		err = m.conn.Aggregate(ctx, &results, pipeline)
+		if err != nil {
+			log.CtxError(ctx, "Aggregate like status error", err)
+			return nil, errorx.ErrFindFailed
+		}
+
+		// 收集已点赞的targetID
+		likedSet := make(map[string]bool)
+		for _, doc := range results {
+			likedSet[doc.ID] = true
+		}
+
+		// 批量设置缓存
+		for _, targetID := range missingIDs {
+			liked := likedSet[targetID] // 如果不存在则为false
+			result[targetID] = liked
+
+			// 异步设置缓存，避免阻塞
+			go func(tID string, status bool) {
+				_ = m.likeCache.SetLikeStatus(ctx, userID, tID, status, 10*time.Minute)
+			}(targetID, liked)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *MongoMapper) GetBatchLikeCount(ctx context.Context, userID string, targetIDs []string, targetType int32) (map[string]int64, error) {
+	if len(targetIDs) == 0 {
+		return make(map[string]int64), nil
+	}
+
+	// 先查缓存
+	cachedResults, missingIDs, err := m.likeCache.GetBatchLikeCount(ctx, targetIDs, targetType)
+	if err != nil {
+		log.Error("Batch get like count from cache error", err)
+		// 缓存失败，直接查数据库
+		missingIDs = targetIDs
+		cachedResults = make(map[string]int64)
+	}
+
+	result := cachedResults
+
+	// 如果有未命中的ID，查询数据库
+	if len(missingIDs) > 0 {
+		// 使用聚合查询批量获取点赞数
+		pipeline := []bson.M{
+			{
+				"$match": bson.M{
+					consts.TargetId: bson.M{"$in": missingIDs},
+					consts.Active:   bson.M{"$ne": false},
+				},
+			},
+			{
+				"$group": bson.M{
+					"_id":   "$" + consts.TargetId,
+					"count": bson.M{"$sum": 1},
+				},
+			},
+		}
+
+		// 临时结果结构体
+		type aggResult struct {
+			ID    string `bson:"_id"`
+			Count int64  `bson:"count"`
+		}
+		var results []aggResult
+
+		// 执行聚合查询，结果填充到 results
+		err = m.conn.Aggregate(ctx, &results, pipeline)
+		if err != nil {
+			log.CtxError(ctx, "Aggregate like count error", err)
+			return nil, errorx.ErrCountFailed
+		}
+
+		// 收集点赞数结果
+		for _, doc := range results {
+			result[doc.ID] = doc.Count
+		}
+
+		// 为没有点赞记录的targetID设置count为0
+		for _, targetID := range missingIDs {
+			if _, exists := result[targetID]; !exists {
+				result[targetID] = 0
+			}
+		}
+
+		// 批量设置缓存
+		for _, targetID := range missingIDs {
+			count := result[targetID]
+			// 异步设置缓存，避免阻塞
+			go func(tID string, cnt int64) {
+				_ = m.likeCache.SetLikeCount(ctx, tID, cnt, 10*time.Minute)
+			}(targetID, count)
+		}
+	}
+
+	return result, nil
 }

--- a/main.go
+++ b/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/Boyuan-IT-Club/Meowpick-Backend/adaptor/router"
 	"github.com/Boyuan-IT-Club/Meowpick-Backend/infra/util/log"
 	"github.com/Boyuan-IT-Club/Meowpick-Backend/provider"
-	"os"
-	"path/filepath"
 )
 
 func Init() {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -5,6 +5,7 @@ package provider
 import (
 	"github.com/Boyuan-IT-Club/Meowpick-Backend/application/dto"
 	"github.com/Boyuan-IT-Club/Meowpick-Backend/application/service"
+	"github.com/Boyuan-IT-Club/Meowpick-Backend/infra/cache"
 	"github.com/Boyuan-IT-Club/Meowpick-Backend/infra/config"
 	"github.com/Boyuan-IT-Club/Meowpick-Backend/infra/consts/consts"
 	"github.com/Boyuan-IT-Club/Meowpick-Backend/infra/mapper/comment"
@@ -61,6 +62,8 @@ var InfrastructureSet = wire.NewSet(
 	like.NewMongoMapper,
 	course.NewMongoMapper,
 	teacher.NewMongoMapper,
+	// 缓存相关
+	cache.NewLikeCache,
 )
 
 var DTOSet = wire.NewSet(


### PR DESCRIPTION
perf:为comment设立缓存，实现批量缓存查询和数据库查询
fix:修复GetLikeStatus，使用查看评论的用户作为userID而非评论作者
Apifox中暂用本地数据库测试，（通过前置脚本，在50个courseID中随机选择一个作为请求参数）结果较之前有了较大改善